### PR TITLE
Fixing image layout.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # Eir: Simulate Epidemics Using Spatial Models in Python
 
 [![DOI](https://joss.theoj.org/papers/10.21105/joss.03247/status.svg)](https://doi.org/10.21105/joss.03247)
+
 ![alt text](https://cdn.shopify.com/s/files/1/1879/3511/files/Eir_grande.jpg?v=1552614189)
+
+
 Eir, named after the Norse valkyrie with great medical skill, is an API that allows the user to conduct stochastic simulations of epidemics, primarily using spatial models. With this software, one can simulate not only how epidemics relate to the distances between an infectious and susceptible indivdual, but also how the movement on infectious individuals plays a role in the spread of a disease. Eir also offers a lot of variety to the user, containing many more compartmental models that is present in any of the existing packages similar to Eir, including hospitalizations and vaccinations. Eir's usefulness can clearly be seen in modern day, where simulations and models are constantly used to form policy to combat COVID-19.
 ## Dependencies
 Eir depends on ```numpy```, ```pandas```, ```matplotlib```, and ```multipledispatch```.


### PR DESCRIPTION
Fixing the image layout of Eir so that it doesn't intrude upon the text in the README.md file or the JOSS DOI badge. 